### PR TITLE
add support for morphTo relationship to NestedCreateRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ class AlbumResource extends NestedResource
         return Ancestor::make(
             ArtistResource::class, // Parent Resource Class
             // Optionally you can pass a relationship name, if it's non-standard. The plugin will try to guess it otherwise
+            // e.g. the 'morphable' method of a morphTo relationship
         );
     }
 }

--- a/src/Pages/NestedCreateRecord.php
+++ b/src/Pages/NestedCreateRecord.php
@@ -2,10 +2,11 @@
 
 namespace Guava\Filament\NestedResources\Pages;
 
+use Illuminate\Support\Arr;
 use Filament\Resources\Pages\CreateRecord;
 use Guava\Filament\NestedResources\Ancestor;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Arr;
 
 class NestedCreateRecord extends CreateRecord
 {
@@ -30,6 +31,10 @@ class NestedCreateRecord extends CreateRecord
         $fake = new (static::getModel())();
         /** @var BelongsTo $relation */
         $relation = $fake->{$ancestor->getRelationship()}();
+
+        if ($relation instanceof MorphTo) {
+            return [$relation->getForeignKeyName() => $record->id, $relation->getMorphType() => get_class($record)];
+        }
 
         return [$relation->getForeignKeyName() => $record->id];
     }


### PR DESCRIPTION
I needed this functionality - thought I'd PR it.

When setting the `getAncestor` on a nested resource you need to pass the `morphable` relation name usewd in the model e.g.

```
public static function getAncestor() : ?Ancestor
    {
        return Ancestor::make(
            SectionResource::class,
            'commentable'
        );
    } 
```
