### PR TITLE
Attempt to redirect to View before Edit page

### DIFF
--- a/src/Pages/NestedEditRecord.php
+++ b/src/Pages/NestedEditRecord.php
@@ -26,18 +26,17 @@ class NestedEditRecord extends EditRecord
 
         $ancestorResource = $ancestor->getResource();
 
+        $urlParameters = $ancestor->getNormalizedRouteParameters($this->getRecord());
+
+        $redirectUrl = match (true) {
+            $resource::hasPage('index') => $resource::getUrl('index', $urlParameters),
+            $ancestorResource::hasPage('view') => $ancestorResource::getUrl('view', $urlParameters),
+            default => $ancestorResource::getUrl('edit', $urlParameters),
+        };
+
         $action
             ->authorize($resource::canDelete($this->getRecord()))
-            ->successRedirectUrl(
-                $resource::hasPage('index')
-                    ? $resource::getUrl('index', [
-                        ...$ancestor->getNormalizedRouteParameters($this->getRecord()),
-                    ])
-                    : $ancestorResource::getUrl('edit', [
-                        ...$ancestor->getNormalizedRouteParameters($this->getRecord()),
-                    ])
-            )
-        ;
+            ->successRedirectUrl($redirectUrl);
     }
 
     protected function configureForceDeleteAction(ForceDeleteAction $action): void
@@ -54,18 +53,17 @@ class NestedEditRecord extends EditRecord
 
         $ancestorResource = $ancestor->getResource();
 
+        $urlParameters = $ancestor->getNormalizedRouteParameters($this->getRecord());
+
+        $redirectUrl = match (true) {
+            $resource::hasPage('index') => $resource::getUrl('index', $urlParameters),
+            $ancestorResource::hasPage('view') => $ancestorResource::getUrl('view', $urlParameters),
+            default => $ancestorResource::getUrl('edit', $urlParameters),
+        };
+
         $action
             ->authorize($resource::canForceDelete($this->getRecord()))
-            ->successRedirectUrl(
-                $resource::hasPage('index')
-                    ? $resource::getUrl('index', [
-                        ...$ancestor->getNormalizedRouteParameters($this->getRecord()),
-                    ])
-                    : $ancestorResource::getUrl('edit', [
-                        ...$ancestor->getNormalizedRouteParameters($this->getRecord()),
-                    ])
-            )
-        ;
+            ->successRedirectUrl($redirectUrl);
     }
 
     protected function configureViewAction(ViewAction $action): void

--- a/src/Resources/NestedResource.php
+++ b/src/Resources/NestedResource.php
@@ -62,18 +62,14 @@ abstract class NestedResource extends Resource
         }
 
         if ($ancestor) {
-            $index = $resource::hasPage('index')
-                ? [
-                    $resource::getUrl('index', [
-                        ...$ancestor->getNormalizedRouteParameters($record ?? $relatedRecord),
-                    ]) => $resource::getBreadcrumb(),
-                ]
-                : [
-                    $ancestor->getResource()::getUrl('edit', [
-                        ...$ancestor->getNormalizedRouteParameters($record ?? $relatedRecord),
-                    ]) . '#relation-manager' => $resource::getBreadcrumb(),
-                ];
+            $ancestorResource = $ancestor->getResource();
+            $urlParameters = $ancestor->getNormalizedRouteParameters($record ?? $relatedRecord);
 
+            $index = match (true) {
+                $resource::hasPage('index') =>  [$resource::getUrl('index', $urlParameters) => $resource::getBreadcrumb()],
+                $ancestorResource::hasPage('view') => [$ancestorResource::getUrl('view', $urlParameters) . '#relation-manager' => $resource::getBreadcrumb()],
+                default => [$ancestorResource::getUrl('edit', $urlParameters) . '#relation-manager' => $resource::getBreadcrumb()],
+            };
         } else {
             $index = [$resource::getUrl('index') => $resource::getBreadcrumb()];
         }


### PR DESCRIPTION
When a resource is deleted or force deleted, the package by default redirects to edit page of parent resource (if index doesnt exist).
I feel like it should prioritize view page of parent resource as well.
```
- does index page of resource exist ? redirect to it
- does view page of parent resource exist ? redirect to it
- fallback to edit page of parent resource
```

Same thing with breadcrumbs - they will now attempt to redirect to view before edit

If you know a better way to achieve this then please do tell me, I've been stuck on this for quite a while (the breadcrumbs) and have not found a solution apart from overriding the whole `getBreadcrumbs` method which would be very confusing.