### PR TITLE
added the ability to use resolveRelationUsing and still use the package

### DIFF
--- a/src/Ancestor.php
+++ b/src/Ancestor.php
@@ -42,6 +42,10 @@ class Ancestor
             return $record->{Str::plural($this->getRelationshipName())}();
         }
 
+        if ($record->relationResolver($record::class, $this->getRelationshipName()) ){
+            return $record->{$this->getRelationshipName()}();
+        }
+
         return null;
     }
 
@@ -51,6 +55,10 @@ class Ancestor
             return $record->{$this->getInverseRelationshipName()}();
         }
 
+        if ($record->relationResolver($record::class, $this->getInverseRelationshipName()) != null){
+            return $record->{$this->getInverseRelationshipName()}();
+        }
+        
         return null;
     }
 


### PR DESCRIPTION
This will add the possibility to use resolveRelationUsing to add relations to existing models, as per the laravel documenation.

It can be useful in scenarios where you have modules and want to keep the code separated for each module, or if you're extending something existing...

An example (following your demo) can be something like the following (in a service provider maybe)

Artist::resolveRelationUsing('albums', function (Artist $artis) {
return $artist->hasMany(Album::class, 'project_id', 'id');
});

to add the albums() relation to the Artist class, without modify the Artist code itself.