### PR TITLE
FIx route [filament.xxx.index] not defined

### DIFF
--- a/src/Pages/CreateRelatedRecord.php
+++ b/src/Pages/CreateRelatedRecord.php
@@ -43,6 +43,8 @@ class CreateRelatedRecord extends Page
 
     protected static bool $canCreateAnother = true;
 
+    public ?string $previousUrl = null;
+
     public function mount(int | string $record): void
     {
         $this->ownerRecord = $this->resolveRecord($record);


### PR DESCRIPTION
FIx route [filament.xxx.index] not defined at /livewire/update request

```php
public static function form(Form $form): Form
    {
        return $form
            ->schema([
                 Forms\Components\FileUpload::make('img');
            ]);
    }
```

When the FileUpload component is present, the system automatically sends a /livewire/update request (`calls: [{path: "", method: "getFormUploadedFiles", params: ["data.img"]}]`). The response body of this request triggers an exception: route [filament.xxx.index] not defined.

```
//file:Guava\FilamentNestedResources\Pages\CreateRelatedRecord

    public function mount(int | string $record): void
    {
        $this->ownerRecord = $this->resolveRecord($record);
        $this->record = null;

        $this->authorizeAccess();

        $this->fillForm();

        $this->previousUrl = url()->previous();
    }

    protected function getCancelFormAction(): Action
    {
        return Action::make('cancel')
            ->label(__('filament-panels::resources/pages/create-record.form.actions.cancel.label'))
            ->url($this->previousUrl ?? static::getResource()::getUrl())
            ->color('gray')
        ;
    }
```
The error occurs in the `getCancelFormAction()` method. In subsequent component calls, the `mount()` method is not executed, causing the `previousUrl` value to be null. To resolve this, `previousUrl` should be set as a public property so that its value can be passed between requests.

