### PR TITLE
Ignore create trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ public static function getBreadcrumbs(Model $record, string $operation): array
 }
 ```
 
+### Overriding NestedCreateAction
+By default a create page must be created when using a `NestedRelationManager`. You can disable this by adding the following to your `ManageRelatedRecords`. This allows you to configure the create action yourself i.e. make it a `slideOver` instead of redirecting to a new page.
+
+```php 
+public static bool $ignoreCreateTrait = false;
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](./.github/CONTRIBUTING.md) for details.

--- a/src/Actions/NestedCreateAction.php
+++ b/src/Actions/NestedCreateAction.php
@@ -9,8 +9,12 @@ trait NestedCreateAction
 {
     protected function configureCreateAction(CreateAction $action): void
     {
-        $resource = $this->getNestedResource();
+        if (static::$ignoreCreateTrait === true) {
+            return;
+        }
 
+        $resource = $this->getNestedResource();
+        
         /** @var Ancestor $ancestor */
         $ancestor = $resource::getAncestor();
 

--- a/src/Actions/NestedCreateAction.php
+++ b/src/Actions/NestedCreateAction.php
@@ -9,7 +9,7 @@ trait NestedCreateAction
 {
     protected function configureCreateAction(CreateAction $action): void
     {
-        if (static::$ignoreCreateTrait === true) {
+        if (isset(static::$ignoreCreateTrait) && static::$ignoreCreateTrait === true) {
             return;
         }
 


### PR DESCRIPTION
Allow the create trait to be ignored so that users are able to configure their own create action such as making it a slideOver