### PR TITLE
Breadcrumb improvements

### DIFF
--- a/src/Concerns/NestedPage.php
+++ b/src/Concerns/NestedPage.php
@@ -2,8 +2,10 @@
 
 namespace Guava\FilamentNestedResources\Concerns;
 
+use Filament\Resources\Pages\ManageRelatedRecords;
 use Guava\FilamentNestedResources\Actions\NestedDeleteAction;
 use Guava\FilamentNestedResources\Actions\NestedForceDeleteAction;
+use Guava\FilamentNestedResources\Pages\CreateRelatedRecord;
 
 trait NestedPage
 {
@@ -42,5 +44,16 @@ trait NestedPage
         }
 
         return $breadcrumbs + ['' => $this->getBreadcrumb()];
+    }
+
+    public function getTitle(): string
+    {
+        return static::$title ?? match (true) {
+            $this instanceof CreateRelatedRecord => __('filament-panels::resources/pages/create-record.title', [
+                'label' => static::getNestedResource()::getTitleCaseModelLabel(),
+            ]),
+            $this instanceof ManageRelatedRecords && in_array(NestedPage::class, class_uses_recursive($this)) => static::getNestedResource()::getTitleCasePluralModelLabel(),
+            default => parent::getTitle(),
+        };
     }
 }

--- a/src/Concerns/NestedPage.php
+++ b/src/Concerns/NestedPage.php
@@ -18,23 +18,22 @@ trait NestedPage
 
     public function getBreadcrumbs(): array
     {
+        /** @var \Guava\FilamentNestedResources\Pages\CreateRelatedRecord|\Guava\FilamentNestedResources\Concerns\NestedPage $this */
         if (in_array(static::getResourcePageName(), ['index', 'create'])) {
             return parent::getBreadcrumbs();
         }
 
+        /** @var \Illuminate\Database\Eloquent\Model */
         $record = $this->record ?? $this->getOwnerRecord();
+        /** @var class-string<\Guava\FilamentNestedResources\Concerns\NestedResource> */
         $resource = static::getResource();
-
-        if (! $record) {
-            $record = $this->getOwnerRecord();
-        }
 
         $breadcrumbs = $resource::getBreadcrumbs($record, static::getResourcePageName());
 
         while ($ancestor = $resource::getAncestor()) {
 
             $record = $ancestor->getRelatedRecord($record);
-            if (! $record) {
+            if (!$record) {
                 break;
             }
 
@@ -42,6 +41,6 @@ trait NestedPage
             $breadcrumbs = $resource::getBreadcrumbs($record, static::getResourcePageName()) + $breadcrumbs;
         }
 
-        return $breadcrumbs + ['#' => $this->getBreadcrumb()];
+        return $breadcrumbs + ['' => $this->getBreadcrumb()];
     }
 }

--- a/src/Concerns/NestedRelationManager.php
+++ b/src/Concerns/NestedRelationManager.php
@@ -25,4 +25,9 @@ trait NestedRelationManager
 
         return Filament::getModelResource($record ?? $this->getRelationship()->getRelated());
     }
+
+    public function getBreadcrumb(): string
+    {
+        return static::$breadcrumb ?? __('filament-panels::resources/pages/list-records.breadcrumb');
+    }
 }

--- a/src/Pages/CreateRelatedRecord.php
+++ b/src/Pages/CreateRelatedRecord.php
@@ -274,6 +274,11 @@ class CreateRelatedRecord extends Page
         ;
     }
 
+    public function getBreadcrumb(): string
+    {
+        return static::$breadcrumb ?? __('filament-panels::resources/pages/create-record.breadcrumb');
+    }
+
     public function form(Form $form): Form
     {
         return $form;


### PR DESCRIPTION
If we look at the breadcrumb of the edit view:

[http://127.0.0.1:8000/admin/albums/1/edit]()

The breadcrumb currently appears as:
`Artists > 1 > Albums > 1 > Edit`

However, the link to "Albums" does not use the resource URL correctly.

This issue originates from the `getBreadcrumbs` function in the `Concerns\NestedResources` file, specifically the `$indexUrl` variable and the `$resourceParent::hasPage(.index)` check.

If we compare this with the relationship edit view:
[http://127.0.0.1:8000/admin/artists/1/albums]()

The breadcrumb currently appears as:
`Artists > 1 > Manage Artist Albums`
It should instead be:
`Artists > 1 > Albums > Manage Artist Albums`

To achieve this, the `getBreadcrumbs` function in `Concerns\NestedResources` needs to be updated (modifying the `$relationUrl` variable to use the resource and determining if the operation refers to managing the relationship). Since the "Manage" page uses `Concerns\NestedPage`, which ultimately calls the resource's `getBreadcrumbs` function, this adjustment ensures consistency.

Similarly, in the creation view:
[http://127.0.0.1:8000/admin/artists/1/albums/create]()
The breadcrumb currently appears as:
`Artists > 1 > Create Artist Album`
It should instead be:
`Artists > 1 > Albums > Create Artist Album`
since "Albums" is missing as an identifier.

Lastly, in both the create and edit views, the title becomes overly repetitive and lengthy. To improve this, `getBreadcrumb`  has been adjusted:
 - `Artists > 1 > Albums > List`
 - `Artists > 1 > Albums > Create`

Additionally, `getTitle` has been modified for consistency:
 - "Create [SingularModel]" for the create view
 - "[PluralModel]" for the manage view
This aligns with how non-nested resources are handled in Filament.
